### PR TITLE
Add temp workdir pipeline with atomic publishes for early legos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # PVVP / CSCOPIED Matcher — Milestone 1
 
-
 ## 1) Install
 ```sh
 pip install -e .
+```
+
+## Temp workdir pipeline
+Each lego runs inside a temporary directory that mirrors `input/`, `work/`, `out/`, and `logs/`. Inputs are copied into `input/`, processing occurs in `work/`, and results are staged in `out/` then published atomically to the session folder.
+
+Example:
+```sh
+python pvvp/L03_normalize.py --session EV --project-root /path/to/pvvp --readonly --keep-workdir
+python pvvp/L04_chunker.py --session EV --project-root /path/to/pvvp --readonly --keep-workdir
+```

--- a/pvvp/main_orchestrator.py
+++ b/pvvp/main_orchestrator.py
@@ -213,7 +213,7 @@ class Orchestrator:
         script_path = (self.project_root / script_rel).resolve()
         if not script_path.exists():
             return False, f"lego script missing: {script_path}"
-        rc, out, err = run_py(script_path, *args)
+        rc, out, err = run_py(script_path, *args, "--project-root", str(self.project_root))
         ok = rc == 0
         log = out.strip() + ("\n" + err.strip() if err.strip() else "")
         append_line(self.summary_path, f"{now_utc_ts()} | LEGO {key} rc={rc}")

--- a/pvvp/temp_utils.py
+++ b/pvvp/temp_utils.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+from pathlib import Path
+import os
+import shutil
+import tempfile
+import time
+
+
+def make_temp_root(prefix: str = "pvvp_") -> Path:
+    """Create the root temp directory with required subfolders."""
+    base = os.environ.get("LOCALAPPDATA") or None
+    temp_root = Path(tempfile.mkdtemp(prefix=prefix, dir=base))
+    for sub in ("input", "work", "out", "logs"):
+        (temp_root / sub).mkdir(parents=True, exist_ok=True)
+    return temp_root
+
+
+def atomic_publish(src: Path, dest: Path) -> None:
+    """Atomically publish ``src`` to ``dest`` using a .partial temp and best-effort lock."""
+    dest = dest.resolve()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    partial = dest.with_suffix(dest.suffix + ".partial")
+    if src != partial:
+        shutil.copy2(src, partial)
+    lock = dest.with_suffix(dest.suffix + ".lock")
+    for _ in range(5):
+        try:
+            fd = os.open(str(lock), os.O_CREAT | os.O_EXCL | os.O_WRONLY)
+            os.close(fd)
+            break
+        except FileExistsError:
+            time.sleep(0.2)
+    os.replace(partial, dest)
+    try:
+        os.remove(lock)
+    except FileNotFoundError:
+        pass


### PR DESCRIPTION
## Summary
- add `temp_utils` with helpers to create temp directories and atomically publish files
- run L03_normalize and L04_chunker inside per-run temp dirs with `--workdir`, `--keep-workdir`, and `--readonly` flags
- ensure orchestrator always passes `--project-root` to legos and document temp workflow

## Testing
- `python -m py_compile pvvp/temp_utils.py pvvp/L03_normalize.py pvvp/L04_chunker.py pvvp/main_orchestrator.py`
- `python pvvp/L03_normalize.py --session EV --project-root pvvp --readonly --keep-workdir`
- `python pvvp/L04_chunker.py --session EV --project-root pvvp --readonly --keep-workdir`


------
https://chatgpt.com/codex/tasks/task_e_68b48a0a3170832b98226a029e66d16f