### PR TITLE
Fix L03/L04 invocation & logging; module mode, package imports, surfaced errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Each lego runs inside a temporary directory that mirrors `input/`, `work/`, `out
 
 Example:
 ```sh
-python pvvp/L03_normalize.py --session EV --project-root /path/to/pvvp --readonly --keep-workdir
-python pvvp/L04_chunker.py --session EV --project-root /path/to/pvvp --readonly --keep-workdir
+python -m pvvp.L03_normalize --session EV --project-root /path/to/pvvp --readonly --keep-workdir
+python -m pvvp.L04_chunker --session EV --project-root /path/to/pvvp --readonly --keep-workdir
 ```
+
+Develop on a local feature branch and push it to a remote branch before merging. Opening a pull request from your feature branch ensures the remote history remains clean and reviewable.

--- a/pvvp/__init__.py
+++ b/pvvp/__init__.py
@@ -1,0 +1,1 @@
+"""PVVP package."""


### PR DESCRIPTION
## Summary
- add package init and switch to module-based lego invocation
- improve L03/L04 diagnostics, prechecks, and error logging
- orchestrator runs legos via `-m` modules and surfaces stderr

## Testing
- `python -m pvvp.L03_normalize --session EV --project-root /workspace/COMP_ALYZ/pvvp --keep-workdir --readonly`
- `python -m pvvp.L04_chunker --session EV --project-root /workspace/COMP_ALYZ/pvvp --keep-workdir --readonly`
- `python - <<'PY'
from pathlib import Path
from pvvp.main_orchestrator import Orchestrator
orch = Orchestrator(Path('pvvp'), 'EV')
orch.run_normalize()
orch.run_chunker()
PY`
- `python -m pvvp.L04_chunker --session NOSUCH --project-root /workspace/COMP_ALYZ/pvvp --keep-workdir --readonly` *(fails: Missing normalized text)*

------
https://chatgpt.com/codex/tasks/task_e_68b49d400980832baae796736b412f62