### PR TITLE
Fix L06 argparse & adopt temp-workdir; orchestrator module checks, stderr surfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ Example:
 ```sh
 python -m pvvp.L03_normalize --session EV --project-root /path/to/pvvp --readonly --keep-workdir
 python -m pvvp.L04_chunker --session EV --project-root /path/to/pvvp --readonly --keep-workdir
+python -m pvvp.L06_mapper  --session EV --project-root /path/to/pvvp --readonly --keep-workdir
 ```
+
+Modules must be run with `-m` so package imports resolve correctly. `L06_mapper` now accepts common flags (`--session/--session-id`, `--project-root`, `--workdir`, `--keep-workdir`, `--readonly`, `--diag`) and safely ignores unknown arguments.
+
+The orchestrator runs each step via module mode, surfaces stderr, and skips optional modules (such as `L09_export_positives` and `L13_summary_finalize`) if they are not present.
 
 Develop on a local feature branch and push it to a remote branch before merging. Opening a pull request from your feature branch ensures the remote history remains clean and reviewable.

--- a/pvvp/L09_export_positives.py
+++ b/pvvp/L09_export_positives.py
@@ -1,0 +1,8 @@
+import sys
+
+def main():
+    print("[L09] (stub) Export positives skipped.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pvvp/L13_summary_finalize.py
+++ b/pvvp/L13_summary_finalize.py
@@ -1,0 +1,8 @@
+import sys
+
+def main():
+    print("[L13] (stub) Summary finalize skipped.")
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- make L06_mapper robust to stray flags, adopt temp workdir + atomic publish, and log errors
- harden orchestrator to run modules with `-m`, check existence, and surface stderr; add stubs for optional steps
- document module usage and new L06 flags in README

## Testing
- `python -m pvvp.L06_mapper --session EV --project-root pvvp --keep-workdir --readonly` *(fails: Missing budget_report.json)*
- `python pvvp/main_orchestrator.py --project-root pvvp --input-file pvvp/sessions/EV/input_raw.txt --master-csv pvvp/sessions/EV/pvvp_master.csv --session-id EV` *(runs normalize/chunker, mapper fails: OPENAI_API_KEY is not set)*

------
https://chatgpt.com/codex/tasks/task_e_68b4a049dc50832b8ab3be6443d7d757