### PR TITLE
Merge (LV→LV): normalize + contains + fuzzy; map by LV master; diagnostics for MCAICE

### DIFF
--- a/pvvp/tests/test_merge.py
+++ b/pvvp/tests/test_merge.py
@@ -33,11 +33,11 @@ def make_session(tmp_path: Path) -> tuple[Path, list[str]]:
     allow_nrs = []
     with (session_dir / "pvvp_master.csv").open("w", encoding="utf-8", newline="") as f:
         writer = csv.writer(f)
-        writer.writerow(["Nr Code", "Variable Name", "Section TT"])
+        writer.writerow(["Nr Code", "Variable Name", "Variable Name LV", "Section TT"])
         for i, name in enumerate(allow_names, start=1):
             nr = f"NR{i}"
             allow_nrs.append(nr)
-            writer.writerow([nr, name, ""])
+            writer.writerow([nr, "", name, ""])
     with (session_dir / f"LV_{session}PVVP.txt").open("w", encoding="utf-8") as f:
         for nr in allow_nrs:
             f.write(nr + "\n")

--- a/pvvp/textnorm.py
+++ b/pvvp/textnorm.py
@@ -6,12 +6,31 @@ DASHES = {
     "\u2212": "-",
 }
 
+SPACES = {
+    "\u00A0": " ",
+    "\u2007": " ",
+    "\u202F": " ",
+}
+
 
 def norm_basic(s: str) -> str:
     if s is None:
         return ""
     s = unicodedata.normalize("NFKC", s)
     s = s.translate(str.maketrans(DASHES))
-    s = s.replace("\u00A0", " ").replace("\u2007", " ").replace("\u202F", " ")
+    s = s.translate(str.maketrans(SPACES))
     s = re.sub(r"[ \t]+", " ", s)
     return s.strip()
+
+
+def norm_lv(s: str) -> str:
+    if s is None:
+        return ""
+    s = unicodedata.normalize("NFKC", s)
+    s = s.translate(str.maketrans(DASHES))
+    s = s.translate(str.maketrans(SPACES))
+    # collapse spaces/tabs (keep newlines if needed)
+    s = re.sub(r"[ \t]+", " ", s)
+    # join digits + unit letters like "12 V" -> "12V", "10 Kw" -> "10Kw"
+    s = re.sub(r"(\d)\s+([A-Za-zĀ-ž])", r"\1\2", s)
+    return s.strip().lower()


### PR DESCRIPTION
## Summary
- add LV-focused normalizer handling dashes, spaces, and digit-unit joins
- index LV masterlist and map mentions via equality, containment, or fuzzy with hints
- output mapping diagnostics and include stats/samples in merge reports

## Testing
- `pip install python-dotenv` *(fails: Could not connect to proxy)*
- `PYTHONPATH=. pytest pvvp/tests/test_merge.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68b4b95006ac832b9bcdc40791a0ba13