### PR TITLE
feat: centralize OpenAI env config

### DIFF
--- a/check1.py
+++ b/check1.py
@@ -1,12 +1,11 @@
-import os
 import requests
+from pvvp.common.env_setup import load_env, get_openai_config, mask
 
-api_key = os.getenv("OPENAI_API_KEY")
-if not api_key:
-    print("OPENAI_API_KEY not set.")
-    exit(1)
-
-url = "https://api.openai.com/v1/models"
+load_env()
+cfg = get_openai_config()
+api_key = cfg["api_key"]
+print("OPENAI_API_KEY:", mask(api_key))
+url = cfg["base_url"].rstrip("/") + "/models"
 headers = {"Authorization": f"Bearer {api_key}"}
 
 resp = requests.get(url, headers=headers)

--- a/check3.py
+++ b/check3.py
@@ -1,14 +1,10 @@
-import os
-from dotenv import load_dotenv
-
-load_dotenv()  # reads .env from cwd
-OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
-if not OPENAI_API_KEY:
-    raise RuntimeError("OPENAI_API_KEY is not set. Put it in your .env file.")
-
+from pvvp.common.env_setup import load_env, get_openai_config, mask
 from openai import OpenAI
 
-client = OpenAI(api_key=OPENAI_API_KEY)  # or just OpenAI() if .env is loaded
+load_env()
+cfg = get_openai_config()
+print("OPENAI_API_KEY:", mask(cfg["api_key"]))
+client = OpenAI(api_key=cfg["api_key"])  # or just OpenAI() if .env is loaded
 
 models = client.models.list()
 for m in models.data:

--- a/env_test.py
+++ b/env_test.py
@@ -24,18 +24,22 @@ print("👋 running env_test.py")
 print("python:", sys.version)
 print("cwd:", os.getcwd())
 
+from pvvp.common.env_setup import load_env, get_openai_config, mask
+
 try:
-    from dotenv import load_dotenv, find_dotenv
-    # search upwards for a .env; don't override existing env vars
-    loaded = load_dotenv(find_dotenv(), override=False)
-    print("dotenv imported:", True, "| load_dotenv() returned:", loaded)
+    loaded = load_env(override=False)
+    print("dotenv imported:", True, "| load_env() loaded:", [str(p) for p in loaded])
 except Exception as e:
     if pytest:
-        pytest.fail(f"❌ python-dotenv import/load failed: {e!r}")
+        pytest.fail(f"❌ env load failed: {e!r}")
     else:
         raise
 
-key = os.getenv("OPENAI_API_KEY")
-print("OPENAI_API_KEY present:", bool(key))
-if key:
-    print("key length:", len(key))
+try:
+    cfg = get_openai_config()
+    key = cfg["api_key"]
+    print("OPENAI_API_KEY present:", bool(key))
+    if key:
+        print("key length:", len(key), "| preview:", mask(key))
+except Exception as e:
+    print("❌", e)

--- a/pvvp/common/env_setup.py
+++ b/pvvp/common/env_setup.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+from typing import Dict, List, Optional
+
+try:
+    from dotenv import load_dotenv, find_dotenv
+except Exception:  # pragma: no cover
+    load_dotenv = None
+    find_dotenv = None
+
+_LOADED_PATHS: List[Path] = []
+
+
+def _safe_load(path: Path, override: bool) -> None:
+    if load_dotenv is None:
+        return
+    if path and path.exists():
+        load_dotenv(dotenv_path=str(path), override=override, encoding="utf-8")
+        _LOADED_PATHS.append(path)
+
+
+def load_env(override: bool = False) -> List[Path]:
+    """Load .env files with defined precedence.
+
+    Precedence (later overrides earlier if override=True):
+      1) repo root .env
+      2) pvvp/.env
+      3) nearest .env discovered from CWD
+    Returns list of loaded paths in order.
+    """
+    _LOADED_PATHS.clear()
+    root = Path(__file__).resolve().parents[2]
+    pvvp_dir = root / "pvvp"
+
+    _safe_load(root / ".env", override=False)
+    _safe_load(pvvp_dir / ".env", override=True if not override else True)
+
+    if find_dotenv is not None:
+        discovered = find_dotenv(filename=".env", usecwd=True)
+        if discovered:
+            p = Path(discovered).resolve()
+            _safe_load(p, override=True if override else False)
+
+    return list(_LOADED_PATHS)
+
+
+def mask(s: Optional[str]) -> str:
+    if not s:
+        return "<empty>"
+    s = str(s)
+    if len(s) <= 12:
+        return s[0:2] + "****" + s[-2:]
+    return s[0:6] + "****" + s[-4:]
+
+
+def get_openai_config() -> Dict[str, str]:
+    """Return OpenAI config from environment variables.
+
+    Env names supported for API key:
+      OPENAI_API_KEY, OPENAI_APIKEY, OPENAI_TOKEN
+    Optional env vars:
+      OPENAI_BASE_URL (default https://api.openai.com/v1)
+      OPENAI_MODEL (default gpt-4o-mini)
+    """
+    api_key = (
+        os.getenv("OPENAI_API_KEY")
+        or os.getenv("OPENAI_APIKEY")
+        or os.getenv("OPENAI_TOKEN")
+        or ""
+    ).strip()
+
+    base_url = (os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1").strip()
+    model = (os.getenv("OPENAI_MODEL") or "gpt-4o-mini").strip()
+
+    if not api_key:
+        loaded = " | ".join(str(p) for p in _LOADED_PATHS) or "(no .env loaded)"
+        raise EnvironmentError(
+            "OPENAI_API_KEY not found.\n"
+            "Add it to one of these locations and retry:\n"
+            f" - {Path.cwd() / '.env'} (current CWD)\n"
+            f" - {Path(__file__).resolve().parents[2] / '.env'} (repo root)\n"
+            f" - {Path(__file__).resolve().parents[2] / 'pvvp' / '.env'} (pvvp)\n"
+            f"Loaded .env files: {loaded}"
+        )
+
+    return {"api_key": api_key, "base_url": base_url, "model": model}

--- a/pvvp/env_test.py
+++ b/pvvp/env_test.py
@@ -1,12 +1,11 @@
-# env_test.py
-import os
-from dotenv import load_dotenv
+from pathlib import Path
+from pvvp.common.env_setup import load_env, get_openai_config, mask
 
-load_dotenv()  # loads .env from the current working directory (or parents)
-key = os.getenv("OPENAI_API_KEY")
-
-print("cwd:", os.getcwd())
-if key and key.startswith("sk-"):
-    print(f"✅ OPENAI_API_KEY loaded: length={len(key)} (value hidden)")
-else:
-    print("❌ OPENAI_API_KEY not found. Make sure you created a .env file next to env_test.py.")
+print("cwd:", Path().resolve())
+loaded = load_env(override=False)
+print("Loaded .env files:", [str(p) for p in loaded])
+try:
+    cfg = get_openai_config()
+    print(f"✅ OPENAI_API_KEY loaded: {mask(cfg['api_key'])}")
+except Exception as e:
+    print("❌", e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ dependencies = [
 "pandas>=2.0",
 "pydantic>=2.6",
 "pyyaml>=6.0",
+"python-dotenv>=1.0,<2",
+"requests>=2.31",
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-﻿python-dotenv>=1.0,<2
-# If you use these elsewhere, add them too:
-# requests>=2.31
+python-dotenv>=1.0,<2
+requests>=2.31
 # rapidfuzz>=3.0

--- a/tools/check_env.py
+++ b/tools/check_env.py
@@ -1,0 +1,10 @@
+from pathlib import Path
+from pvvp.common.env_setup import load_env, get_openai_config, mask
+
+print("CWD:", Path().resolve())
+loaded = load_env(override=False)
+print("Loaded .env files:", [str(p) for p in loaded])
+cfg = get_openai_config()
+print("OPENAI_API_KEY:", mask(cfg["api_key"]))
+print("OPENAI_BASE_URL:", cfg["base_url"])
+print("OPENAI_MODEL:", cfg["model"])


### PR DESCRIPTION
## Summary
- add shared env_setup module to load OpenAI config with masking helpers
- refactor mapper and semantic pass scripts to use central loader and configurable base URL
- include check_env tool and update dependencies

## Testing
- `PYTHONPATH=. OPENAI_API_KEY=sk-test python tools/check_env.py`
- `PYTHONPATH=. OPENAI_API_KEY=sk-test python pvvp/env_test.py`
- `PYTHONPATH=. OPENAI_API_KEY=sk-test python pvvp/L06_semantic_pass.py --help`
- `PYTHONPATH=. OPENAI_API_KEY=sk-test python pvvp/L06_mapper.py --help`
- `PYTHONPATH=. OPENAI_API_KEY=sk-test python check1.py` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_68b4ce19c564832bba93988ddc64549b